### PR TITLE
GetReg & friends should ensure Reg is mapped

### DIFF
--- a/Docs/DeviceDrivers.md
+++ b/Docs/DeviceDrivers.md
@@ -439,6 +439,14 @@ can only perform I/O using the DT I/O Protocol functions (`ReadReg()` and
 friends, and [only if the ancestor device driver implements the I/O
 callbacks](../Drivers/FdtBusDxe/DtIo.c#L438)).
 
+> [!NOTE]
+> When the `EFI_DT_REG` describes a CPU-accessible region, `GetReg()` and
+> related calls ensure the region is accessible (e.g. mapped for
+> access). If the region is not present in the GCD, it is added
+> as a region of type `EfiGcdMemoryTypeMemoryMappedIo` with attributes
+> `EFI_MEMORY_UC`. If a `EfiGcdMemoryTypeMemoryMappedIo` region
+> already exists with different attributes, it is left unchanged.
+
 ## Critical Device Drivers
 
 Typically, a UEFI environment only initializes the devices required to

--- a/Docs/DtIoProtocol.md
+++ b/Docs/DtIoProtocol.md
@@ -454,12 +454,26 @@ advanced operations, such as filling a range with the same value,
 or writing out a buffer into a single register. Ultimately
 the accesses are performed via `EFI_CPU_IO2_PROTOCOL`.
 
+It is also possible to perform I/O without using `PollReg()`, `ReadReg()`,
+`WriteReg()` and `CopyReg()`. The `EFI_DT_REG` `TranslatedBase` field
+contains an `EFI_PHYSICAL_ADDDRESS` (a valid CPU address), when
+the `BusDtIo` field is `NULL`, with the latter meaning there is a
+direct translation between the _reg_ (bus) and CPU addresses.
+
 It's possible there is no direct translation between bus
 and CPU addresses. For example, PHY register accesses might involve
 a custom mechanism only known to a NIC driver. Unless the parent DT
 controller device driver set child register read and write callbacks
 via `SetCallbacks()`, calls to read, write, poll and copy registers
 will fail with `EFI_UNSUPPORTED`.
+
+> [!NOTE]
+> When the `EFI_DT_REG` describes a CPU-accessible region, `GetReg()` and
+> related calls ensure the region is accessible (e.g. mapped for
+> access). If the region is not present in the GCD, it is added
+> as a region of type `EfiGcdMemoryTypeMemoryMappedIo` with attributes
+> `EFI_MEMORY_UC`. If a `EfiGcdMemoryTypeMemoryMappedIo` region
+> already exists with different attributes, it is left unchanged.
 
 ### DMA
 
@@ -921,12 +935,6 @@ EFI_STATUS
 Looks up a _reg_ property value by index, returning an
 `EFI_DT_REG`. The latter can be passed to the [register access API](#register-access).
 
-> [!NOTE]
-> The returned address is in CPU space, not bus space,
-> if these are different. That is, `GetReg()` performs
-> automatic address translation, and does not return
-> the raw values encoded in the Devicetree property.
-
 > [!CAUTION]
 > Only support for direct translation is implemented today (CPU == bus addresses).
 
@@ -967,12 +975,6 @@ Looks up a _reg_ property value by name, returning an
 
 > [!NOTE]
 > Lookup by name involves examining the _reg-names_ property.
-
-> [!NOTE]
-> The returned address is in CPU space, not bus space,
-> if these are different. That is, `GetRegByName()` performs
-> automatic address translation, and does not return
-> the raw values encoded in the Devicetree property.
 
 > [!CAUTION]
 > Only support for direct translation is implemented today (CPU == bus addresses).

--- a/Drivers/FdtBusDxe/DtIoPropParse.c
+++ b/Drivers/FdtBusDxe/DtIoPropParse.c
@@ -497,6 +497,25 @@ DtIoParsePropReg (
 
   if (BusDevice != NULL) {
     Reg->BusDtIo = &BusDevice->DtIo;
+  } else {
+    Status = ApplyGcdTypeAndAttrs (
+               Reg->TranslatedBase,
+               Reg->Length,
+               EfiGcdMemoryTypeMemoryMappedIo,
+               EFI_MEMORY_UC,
+               TRUE
+               );
+    ASSERT_EFI_ERROR (Status);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: ApplyGcdTypeAndAttrs: %r\n",
+        __func__,
+        Status
+        ));
+      ASSERT_EFI_ERROR (Status);
+      goto Out;
+    }
   }
 
 Out:

--- a/Drivers/FdtBusDxe/FdtBusDxe.h
+++ b/Drivers/FdtBusDxe/FdtBusDxe.h
@@ -18,6 +18,7 @@
 #include <Library/UefiLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Library/DxeServicesTableLib.h>
 #include <Library/UefiDriverEntryPoint.h>
 #include <Library/HobLib.h>
 #include <Library/DevicePathLib.h>
@@ -29,6 +30,9 @@
 #define DT_DEV_SIGNATURE  SIGNATURE_32 ('d', 't', 'i', 'o')
 #define DT_DEV_FROM_THIS(a)  CR(a, DT_DEVICE, DtIo, DT_DEV_SIGNATURE)
 #define DT_DEV_FROM_LINK(a)  CR(a, DT_DEVICE, Link, DT_DEV_SIGNATURE)
+
+#define ROUND_UP(x, n)    (((x) + n - 1) & ~(n - 1))
+#define ROUND_DOWN(x, n)  ((x) & ~(n - 1))
 
 typedef struct _DT_DEVICE DT_DEVICE;
 
@@ -445,6 +449,15 @@ CHAR8 *
 AsciiStrChr (
   IN  CHAR8  *Str,
   IN  CHAR8  Chr
+  );
+
+EFI_STATUS
+ApplyGcdTypeAndAttrs (
+  IN  EFI_PHYSICAL_ADDRESS  Address,
+  IN  UINTN                 Length,
+  IN  EFI_GCD_MEMORY_TYPE   Type,
+  IN  UINT64                Attributes,
+  IN  BOOLEAN               OnConflictDoNothing
   );
 
 #ifndef MDEPKG_NDEBUG

--- a/Drivers/FdtBusDxe/FdtBusDxe.inf
+++ b/Drivers/FdtBusDxe/FdtBusDxe.inf
@@ -41,6 +41,7 @@
   BaseMemoryLib
   DebugLib
   UefiBootServicesTableLib
+  DxeServicesTableLib
   UefiDriverEntryPoint
   HobLib
   FdtLib

--- a/Drivers/HighMemDxe/DriverBinding.c
+++ b/Drivers/HighMemDxe/DriverBinding.c
@@ -132,8 +132,8 @@ DriverStart (
   IN  EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath OPTIONAL
   )
 {
-  EFI_STATUS                Status;
-  EFI_DT_IO_PROTOCOL        *DtIo;
+  EFI_STATUS          Status;
+  EFI_DT_IO_PROTOCOL  *DtIo;
 
   DtIo   = NULL;
   Status = gBS->OpenProtocol (


### PR DESCRIPTION
Introduces ApplyGcdTypeAndAttrs and uses it in DtIoParsePropReg.

Fixes https://github.com/intel/FdtBusPkg/issues/76

Now, for a device like OVMF RTC:

FS0:\> DtReg.efi  -w 4 soc/rtc@101000  0
Dumping 4 bytes at offset 0x0 of reg via CPU 0x101000(1000):
  00000000: 794E7690