### PR TITLE
DtIo: more boilerplate for non-coherence support

### DIFF
--- a/Docs/DtIoProtocol.md
+++ b/Docs/DtIoProtocol.md
@@ -196,10 +196,14 @@ typedef enum {
 } EFI_DT_IO_PROTOCOL_DMA_OPERATION;
 
 typedef struct {
-#define EFI_DT_IO_DMA_WITH_MAX_ADDRESS BIT0
+  #define EFI_DT_IO_DMA_WITH_MAX_ADDRESS BIT0
+  #define EFI_DT_IO_DMA_NON_COHERENT     BIT1
   ///
   /// When EFI_DT_IO_DMA_WITH_MAX_ADDRESS is set, the MaxAddress
   /// field will be honored.
+  ///
+  /// When EFI_DT_IO_DMA_NON_COHERENT is set, the bus master
+  /// will be treated as not supporting cache coherency.
   ///
   UINT64                Flags;
   ///

--- a/Drivers/PciHostBridgeFdtDxe/RootBridge.c
+++ b/Drivers/PciHostBridgeFdtDxe/RootBridge.c
@@ -1936,7 +1936,6 @@ RootBridgeDtInit (
   // (valid for PC-like systems).
   //
   ASSERT (Status == EFI_NOT_FOUND);
-  ASSERT (DtIo->IsDmaCoherent);
   RootBridge->DmaAbove4G = TRUE;
 
   return EFI_SUCCESS;

--- a/Include/Protocol/DtIo.h
+++ b/Include/Protocol/DtIo.h
@@ -74,9 +74,13 @@ typedef enum {
 
 typedef struct {
   #define EFI_DT_IO_DMA_WITH_MAX_ADDRESS  BIT0
+  #define EFI_DT_IO_DMA_NON_COHERENT      BIT1
   ///
   /// When EFI_DT_IO_DMA_WITH_MAX_ADDRESS is set, the MaxAddress
   /// field will be honored.
+  ///
+  /// When EFI_DT_IO_DMA_NON_COHERENT is set, the bus master
+  /// will be treated as not supporting cache coherency.
   ///
   UINT64                  Flags;
   ///


### PR DESCRIPTION
- Add EFI_DT_IO_DMA_NON_COHERENT to the extra constraints.
- Disallow non-coherence in Map and AllocateBuffer
- Allow non-coherence in PciHostBridgeFdtDxe (which now completely defers to FdtBusDxe for DMA).