### PR TITLE
PciHostBridgeFdtDxe: support fully synthetic PCIe MMIO/IO apertures i…

### DIFF
--- a/Drivers/PciHostBridgeFdtDxe/Driver.h
+++ b/Drivers/PciHostBridgeFdtDxe/Driver.h
@@ -89,6 +89,7 @@ typedef struct {
   UINT64                  Length;
   UINT64                  Alignment;
   RES_STATUS              Status;
+  BOOLEAN                 ResTracked;
 } PCI_RES_NODE;
 
 typedef struct _PCI_ROOT_BRIDGE_INSTANCE PCI_ROOT_BRIDGE_INSTANCE;

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ See the [presentation video](https://www.youtube.com/watch?v=2w9iQE8jA1w) and [s
 
 | When | What |
 | :-: | ------------ |
+| October 2024 | Support indirect access to preconfigured BARs. |
+| September 2024 | Range translation, DMA range narrowing, reg-attrs, range-attrs, improved address-cells and size-cells handling, PciHostBridgeFdtDxe support for indirect configuration space access, legacy VGA ranges, preconfigured BARs. PciInfo tool. |
 | August 2024 | Various fixes, DtInterrupt protocol. |
 | February 2024 | Docs complete. DtInfo, DtProp and DtReg tools added. VirtNorFlashDxe, PciSioSerialDxe, PciHostBridgeFdtDxe drivers ported. Demo video at https://youtu.be/9RqKq4wGYZI. |
 | January 2024 | Open sourced. Work on documentation. |


### PR DESCRIPTION
…n the no-reconfiguration case.

In some scenarios, actual access to a PCIe device could be indirect, i.e. not a 1:1 mapping between a BAR address and a CPU address.

UEFI expects the apertures to be visible in CPU space, which I suppose isn't really a problem for well-written driver code (that uses the PCI IO protocol for all I/O). However, PciHostBridgeFdtDxe and other similar code relies on GCD functions to allocate/validate ranges (see AllocateResource in HostBridge.c), so supporting full configuration in this indirect aperture case would involve an internal allocator (as the "indirect" part implies the PCI MMIO/IO addresses are not part of the GCD!).

The good news is that, so long as we're keeping existing configuration (fdtbuspkg,pci-keep-config), we can limp along. This is useful in the case of UEFI userspace emulation (exposing devices via VFIO) or other non-standard approaches.

The new ResTracked field PCI_RES_NODE tracks whether the resource is tracked in the GCD.